### PR TITLE
NO-JIRA | JS | Remove `os.log` References

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/ConfigCat/ConfigCatClient.swift
+++ b/Sources/ConfigCat/ConfigCatClient.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os.log
 
 /// Describes the location of your feature flag and setting data within the ConfigCat CDN.
 @objc public enum DataGovernance: Int {

--- a/Sources/ConfigCat/ConfigCatOptions.swift
+++ b/Sources/ConfigCat/ConfigCatOptions.swift
@@ -28,7 +28,7 @@ public final class ConfigCatOptions: NSObject {
     @objc public var logLevel: ConfigCatLogLevel = .warning
     
     /// The logger used by the SDK.
-    @objc public var logger: ConfigCatLogger = OSLogger()
+    @objc public var logger: ConfigCatLogger = NoLogger()
 
     /// The default user, used as fallback when there's no user parameter is passed to the getValue() method.
     @objc public var defaultUser: ConfigCatUser? = nil

--- a/Sources/ConfigCat/Log.swift
+++ b/Sources/ConfigCat/Log.swift
@@ -1,5 +1,3 @@
-import os.log
-import os
 import Foundation
 
 @objc public enum ConfigCatLogLevel: Int {
@@ -56,26 +54,6 @@ class InternalLogger {
     
     func enabled(level: ConfigCatLogLevel) -> Bool {
         return level.rawValue >= self.level.rawValue
-    }
-}
-
-class OSLogger: ConfigCatLogger {
-    private static let log: OSLog = OSLog(subsystem: "com.configcat", category: "main")
-    
-    func debug(message: String) {
-        os_log("%{public}@", log: OSLogger.log, type: .debug, message)
-    }
-    
-    func warning(message: String) {
-        os_log("%{public}@", log: OSLogger.log, type: .info, message)
-    }
-    
-    func info(message: String) {
-        os_log("%{public}@", log: OSLogger.log, type: .info, message)
-    }
-    
-    func error(message: String) {
-        os_log("%{public}@", log: OSLogger.log, type: .error, message)
     }
 }
 

--- a/Sources/ConfigCat/RolloutEvaluator.swift
+++ b/Sources/ConfigCat/RolloutEvaluator.swift
@@ -1,6 +1,5 @@
 import Foundation
 import CommonCrypto
-import os.log
 
 #if SWIFT_PACKAGE
 import Version


### PR DESCRIPTION
This SDK was designed for iOS, as a result it may use some dependencies assuming an iOS environment.
Because we're using it with Vapor and its Linux environment, and that Linux does not contains OSLog, we have to remove the OSLog references.

We'll still be able to log events by just conforming to the dedicated ConfigCat logger protocol