### PR TITLE
NO-JIRA | JS | Swapping `CommonCrypto` Dependency for Swift `Crypto`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-asn1",
+        "repositoryURL": "https://github.com/apple/swift-asn1.git",
+        "state": {
+          "branch": null,
+          "revision": "a54383ada6cecde007d374f58f864e29370ba5c3",
+          "version": "1.3.2"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+          "version": "3.12.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -8,16 +8,20 @@ let package = Package(
         .iOS(.v12),
         .watchOS(.v4),
         .tvOS(.v12),
-        .macOS(.v10_13)
+        .macOS(.v10_15)
     ],
     products: [
         .library(name: "ConfigCat", targets: ["ConfigCat"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
     ],
     targets: [
         .target(name: "Version",
                 exclude: ["LICENSE" , "version.txt"]),
         .target(name: "ConfigCat",
-                dependencies: ["Version"],
+                dependencies: ["Version",
+                               .product(name: "Crypto", package: "swift-crypto")],
                 exclude: ["Resources/ConfigCat.h", "Resources/Info.plist"],
                 resources: [.copy("Resources/PrivacyInfo.xcprivacy")],
                 swiftSettings: [

--- a/Sources/ConfigCat/RolloutEvaluator.swift
+++ b/Sources/ConfigCat/RolloutEvaluator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import CommonCrypto
+import Crypto
 
 #if SWIFT_PACKAGE
 import Version
@@ -774,21 +774,15 @@ internal extension Data {
         copy.append(Data((salt + contextSalt).utf8))
         return copy.digestSHA256.hexString
     }
-    
+
     var digestSHA1: Data {
-        var bytes: [UInt8] = Array(repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-        withUnsafeBytes {
-            _ = CC_SHA1($0.baseAddress, CC_LONG(count), &bytes)
-        }
-        return Data(_: bytes)
+        let digest = Insecure.SHA1.hash(data: self)
+        return Data(digest)
     }
-    
+
     var digestSHA256: Data {
-        var bytes: [UInt8] = Array(repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        withUnsafeBytes {
-            _ = CC_SHA256($0.baseAddress, CC_LONG(count), &bytes)
-        }
-        return Data(_: bytes)
+        let digest = SHA256.hash(data: self)
+        return Data(digest)
     }
 
     var hexString: String {


### PR DESCRIPTION
`CommonCrypto` isn't shipped with Swift. As a result, I swap the package with the more modern `Swift Crypto` that we can actually import as a dependency